### PR TITLE
Update predicate types to latest core URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This produces:
   "statements": [
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2028-06-30T23:59:59Z",
         "end_of_security_support": "2028-03-31T23:59:59Z",
         "end_of_sales": "2027-12-31T23:59:59Z",
@@ -175,8 +175,11 @@ data, err := openeox.MarshalShell(shell)
 The module tracks the OASIS OpenEoX specification:
 
 - **openeox-core v1.0**: Fully supported. The `Core` message maps directly
-  to the [upstream JSON schema](https://docs.oasis-open.org/openeox/v1.0/schema/core.json).
+  to the [upstream JSON schema](https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json).
   Conformance is validated against the upstream schema and test data in CI.
+  Documents using the pre-CSD01-RC3 schema URI
+  (`https://docs.oasis-open.org/openeox/v1.0/schema/core.json`, exposed as
+  `CoreSchemaLegacy`) are still accepted when parsing.
 - **openeox-shell**: Tracks the current draft (CSD01). The `Shell`,
   `Statement`, `Product`, and `ProductIdentificationHelper` messages
   follow the draft shell schema structure.

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -31,7 +31,7 @@ func upstreamRepoPath(t *testing.T) string {
 func loadCoreSchemaValidator(t *testing.T, repoPath string) *jsonschema.Schema {
 	t.Helper()
 	metaPath := filepath.Join(repoPath, "eox-core-v-1-0", "schema", "meta.json")
-	corePath := filepath.Join(repoPath, "eox-core-v-1-0", "schema", "eox-core.json")
+	corePath := filepath.Join(repoPath, "eox-core-v-1-0", "schema", "core.json")
 
 	compiler := jsonschema.NewCompiler()
 	compiler.Draft = jsonschema.Draft2020
@@ -43,7 +43,7 @@ func loadCoreSchemaValidator(t *testing.T, repoPath string) *jsonschema.Schema {
 	defer metaFile.Close() //nolint:errcheck
 	require.NoError(t, compiler.AddResource(metaURL, metaFile))
 
-	coreURL := "https://docs.oasis-open.org/openeox/v1.0/schema/core.json"
+	coreURL := CoreSchema
 	coreFile, err := os.Open(corePath)
 	require.NoError(t, err)
 	defer coreFile.Close() //nolint:errcheck

--- a/parser.go
+++ b/parser.go
@@ -30,8 +30,9 @@ type schemaFinder struct {
 
 //nolint:unused
 var typeDict = map[string]reflect.Type{
-	"https://docs.oasis-open.org/openeox/tbd/schema/shell.json": reflect.TypeOf(&v1.Shell{}),
-	"https://docs.oasis-open.org/openeox/v1.0/schema/core.json": reflect.TypeOf(&v1.Core{}),
+	v1.Schema:           reflect.TypeOf(&v1.Shell{}),
+	v1.CoreSchema:       reflect.TypeOf(&v1.Core{}),
+	v1.CoreSchemaLegacy: reflect.TypeOf(&v1.Core{}),
 }
 
 //nolint:unused

--- a/parser_test.go
+++ b/parser_test.go
@@ -131,7 +131,7 @@ func TestParseTBA(t *testing.T) {
 
 	// A core document with "tba" lifecycle dates
 	data := []byte(`{
-		"$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+		"$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
 		"end_of_life": "tba",
 		"end_of_security_support": "tba",
 		"last_updated": "2025-07-01T12:00:00Z"

--- a/testdata/hashes.eox.json
+++ b/testdata/hashes.eox.json
@@ -3,7 +3,7 @@
   "statements": [
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2028-06-30T23:59:59Z",
         "end_of_security_support": "2028-03-31T23:59:59Z",
         "end_of_sales": "2027-12-31T23:59:59Z",

--- a/testdata/latest.eox.json
+++ b/testdata/latest.eox.json
@@ -3,7 +3,7 @@
   "statements": [
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2027-12-31T23:59:59Z",
         "end_of_security_support": "2027-06-30T23:59:59Z",
         "end_of_sales": "2026-12-31T23:59:59Z",
@@ -25,7 +25,7 @@
     },
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2026-09-30T23:59:59Z",
         "end_of_security_support": "2026-03-31T23:59:59Z",
         "end_of_sales": "2025-09-30T23:59:59Z",

--- a/testdata/software-identifiers.eox.json
+++ b/testdata/software-identifiers.eox.json
@@ -3,7 +3,7 @@
   "statements": [
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2029-12-31T23:59:59Z",
         "end_of_security_support": "2029-06-30T23:59:59Z",
         "end_of_sales": "2028-12-31T23:59:59Z",
@@ -35,7 +35,7 @@
     },
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2030-12-31T23:59:59Z",
         "end_of_security_support": "2030-06-30T23:59:59Z",
         "last_updated": "2025-07-01T12:00:00Z",

--- a/types.go
+++ b/types.go
@@ -6,8 +6,9 @@ package openeox
 import latest "github.com/carabiner-dev/openeox/types/v1"
 
 const (
-	Schema     = latest.Schema
-	CoreSchema = latest.CoreSchema
+	Schema           = latest.Schema
+	CoreSchema       = latest.CoreSchema
+	CoreSchemaLegacy = latest.CoreSchemaLegacy
 
 	ProductSoftwareSchema             = latest.ProductSoftwareSchema
 	ProductHardwareSchema             = latest.ProductHardwareSchema

--- a/types/v1/openeox.go
+++ b/types/v1/openeox.go
@@ -5,7 +5,11 @@ package v1
 
 const (
 	Schema     = "https://docs.oasis-open.org/openeox/tbd/schema/shell.json"
-	CoreSchema = "https://docs.oasis-open.org/openeox/v1.0/schema/core.json"
+	CoreSchema = "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json"
+
+	// CoreSchemaLegacy is the core schema URI used by OpenEoX drafts prior
+	// to CSD01 RC3. Documents declaring it are still accepted when parsing.
+	CoreSchemaLegacy = "https://docs.oasis-open.org/openeox/v1.0/schema/core.json"
 
 	ProductSoftwareSchema             = "https://docs.oasis-open.org/openeox/tbd/schema/product_software.json"
 	ProductHardwareSchema             = "https://docs.oasis-open.org/openeox/tbd/schema/product_hardware.json"

--- a/types/v1/testdata/sample.eox.json
+++ b/types/v1/testdata/sample.eox.json
@@ -3,7 +3,7 @@
   "statements": [
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2027-12-31T23:59:59Z",
         "end_of_security_support": "2027-06-30T23:59:59Z",
         "end_of_sales": "2026-12-31T23:59:59Z",
@@ -24,7 +24,7 @@
     },
     {
       "core": {
-        "$schema": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+        "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
         "end_of_life": "2026-09-30T23:59:59Z",
         "end_of_security_support": "2026-03-31T23:59:59Z",
         "end_of_sales": "2025-09-30T23:59:59Z",


### PR DESCRIPTION
This pull request updates the project to use the latest OpenEoX core schema URI and ensures continued compatibility with documents using the legacy schema URI. It also updates test data and type mappings to reflect these changes, and introduces support for both the new and legacy schema URIs during parsing.

**Schema URI updates and compatibility:**

* Updated the `CoreSchema` constant in `types/v1/openeox.go` to use the new schema URI (`https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json`) and introduced `CoreSchemaLegacy` for the previous URI, ensuring that documents using the old URI are still accepted when parsing.
* Updated type mappings in `parser.go` to use the new `CoreSchema` and support both `CoreSchema` and `CoreSchemaLegacy` for correct type resolution.
* Adjusted the schema validator in `conformance_test.go` to reference the new `CoreSchema` constant and updated the file path for the core schema. [[1]](diffhunk://#diff-be4d99d66262dc3750603ef688c69733cfb5ee8f882144967fcf6272da7b080eL34-R34) [[2]](diffhunk://#diff-be4d99d66262dc3750603ef688c69733cfb5ee8f882144967fcf6272da7b080eL46-R46)

**Test data and documentation:**

* Updated all test and sample `.eox.json` files to use the new core schema URI. [[1]](diffhunk://#diff-39c9a6bfe6db39d518155dd2756edba30094a0e3d806a44ceee0fd550b8b0aa5L6-R6) [[2]](diffhunk://#diff-39c9a6bfe6db39d518155dd2756edba30094a0e3d806a44ceee0fd550b8b0aa5L27-R27) [[3]](diffhunk://#diff-f0b809127ec4a064ff40d81266ed062ea294344066c491e23739ec92421560f9L6-R6) [[4]](diffhunk://#diff-f0b809127ec4a064ff40d81266ed062ea294344066c491e23739ec92421560f9L38-R38) [[5]](diffhunk://#diff-36811254ef57e4cf7a17f1adf50d1ce847b25790e27016a1038ab2ecd78879b1L6-R6) [[6]](diffhunk://#diff-36811254ef57e4cf7a17f1adf50d1ce847b25790e27016a1038ab2ecd78879b1L28-R28) [[7]](diffhunk://#diff-10581b004bdfde7a262cbf7cfb9536045402c4acbc4a9ce64c14d1263f2ee3caL6-R6)
* Updated documentation in `README.md` to reflect the new schema URI and clarify support for the legacy URI. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L178-R182)

**Other:**

* Exposed `CoreSchemaLegacy` in the main `types.go` export for use throughout the codebase.
* Updated test cases in `parser_test.go` to use the new schema URI.