### PR TITLE
Implement the Library conformance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ shell, err := parser.ParseShell(data)
 core, err := parser.ParseCore(data)
 ```
 
+Core documents are validated against the upstream OpenEoX core JSON
+schema when parsed; validation errors wrap `openeox.ErrInvalidDocument`.
+Set `Parser.SkipValidation` to parse without validating.
+
+Documents can also be read directly from the file system, a URL or any
+`io.Reader`:
+
+```go
+core, err := parser.ParseCoreFile("product.eox.json")
+core, err := parser.ParseCoreURL(ctx, "https://example.com/product.eox.json")
+core, err := parser.ParseCoreReader(os.Stdin)
+// ... and the equivalent ParseShellFile / ParseShellURL / ParseShellReader
+```
+
 ### Handling "tba" (To Be Announced)
 
 The OpenEoX spec allows lifecycle date fields (`end_of_life`,
@@ -163,11 +177,18 @@ This produces:
 ### Marshaling
 
 Use the provided marshal functions to produce JSON that conforms to the
-upstream OpenEoX schema:
+upstream OpenEoX schema. Object keys are sorted lexicographically, as
+required by the specification's Library conformance profile:
 
 ```go
 data, err := openeox.MarshalCore(core)
 data, err := openeox.MarshalShell(shell)
+
+// String, stream and file system output
+s, err := openeox.MarshalCoreString(core)
+err = openeox.WriteCore(os.Stdout, core)
+err = openeox.WriteCoreFile("product.eox.json", core)
+// ... and the equivalent MarshalShellString / WriteShell / WriteShellFile
 ```
 
 ## Spec Conformance
@@ -180,6 +201,11 @@ The module tracks the OASIS OpenEoX specification:
   Documents using the pre-CSD01-RC3 schema URI
   (`https://docs.oasis-open.org/openeox/v1.0/schema/core.json`, exposed as
   `CoreSchemaLegacy`) are still accepted when parsing.
+  The module targets the specification's **"OpenEoX Core Library"**
+  conformance profile (Conformance Clause 9): parsed core documents are
+  checked against the embedded upstream JSON schema, documents can be read
+  from the file system, URLs and data streams, output keys are sorted, and
+  documents can be written to the file system, strings and data streams.
 - **openeox-shell**: Tracks the current draft (CSD01). The `Shell`,
   `Statement`, `Product`, and `ProductIdentificationHelper` messages
   follow the draft shell schema structure.

--- a/io.go
+++ b/io.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package openeox
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// ParseCoreFile reads an OpenEoX core document from the file system.
+func (p *Parser) ParseCoreFile(path string) (*Core, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading core document: %w", err)
+	}
+	return p.ParseCore(data)
+}
+
+// ParseCoreReader reads an OpenEoX core document from a data stream.
+func (p *Parser) ParseCoreReader(r io.Reader) (*Core, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading core document: %w", err)
+	}
+	return p.ParseCore(data)
+}
+
+// ParseCoreURL fetches an OpenEoX core document from a URL.
+func (p *Parser) ParseCoreURL(ctx context.Context, url string) (*Core, error) {
+	data, err := fetchDocument(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return p.ParseCore(data)
+}
+
+// ParseShellFile reads an OpenEoX shell document from the file system.
+func (p *Parser) ParseShellFile(path string) (*Shell, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading shell document: %w", err)
+	}
+	return p.ParseShell(data)
+}
+
+// ParseShellReader reads an OpenEoX shell document from a data stream.
+func (p *Parser) ParseShellReader(r io.Reader) (*Shell, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading shell document: %w", err)
+	}
+	return p.ParseShell(data)
+}
+
+// ParseShellURL fetches an OpenEoX shell document from a URL.
+func (p *Parser) ParseShellURL(ctx context.Context, url string) (*Shell, error) {
+	data, err := fetchDocument(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return p.ParseShell(data)
+}
+
+// fetchDocument retrieves a document over HTTP(S).
+func fetchDocument(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching document: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching document: %s", resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	return data, nil
+}
+
+// WriteCore serializes a Core document and writes it to a data stream.
+func WriteCore(w io.Writer, core *Core) error {
+	data, err := MarshalCore(core)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing core document: %w", err)
+	}
+	return nil
+}
+
+// WriteCoreFile serializes a Core document and writes it to the file system.
+func WriteCoreFile(path string, core *Core) error {
+	data, err := MarshalCore(core)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing core document: %w", err)
+	}
+	return nil
+}
+
+// MarshalCoreString serializes a Core document to a string.
+func MarshalCoreString(core *Core) (string, error) {
+	data, err := MarshalCore(core)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteShell serializes a Shell document and writes it to a data stream.
+func WriteShell(w io.Writer, shell *Shell) error {
+	data, err := MarshalShell(shell)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing shell document: %w", err)
+	}
+	return nil
+}
+
+// WriteShellFile serializes a Shell document and writes it to the file system.
+func WriteShellFile(path string, shell *Shell) error {
+	data, err := MarshalShell(shell)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing shell document: %w", err)
+	}
+	return nil
+}
+
+// MarshalShellString serializes a Shell document to a string.
+func MarshalShellString(shell *Shell) (string, error) {
+	data, err := MarshalShell(shell)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/io_test.go
+++ b/io_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package openeox
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func testCoreDocument() *Core {
+	return &Core{
+		Schema:               CoreSchema,
+		EndOfLife:            timestamppb.New(time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC)),
+		EndOfSecuritySupport: timestamppb.New(time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC)),
+		EndOfSales:           timestamppb.New(time.Date(2027, 12, 31, 23, 59, 59, 0, time.UTC)),
+		GeneralAvailability:  timestamppb.New(time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC)),
+		LastUpdated:          timestamppb.New(time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)),
+	}
+}
+
+func TestMarshalCoreSortsKeys(t *testing.T) {
+	data, err := MarshalCore(testCoreDocument())
+	require.NoError(t, err)
+	//nolint:testifylint // byte-exact comparison: the test asserts key order
+	require.Equal(t,
+		`{"$schema":"`+CoreSchema+`",`+
+			`"end_of_life":"2028-12-31T23:59:59Z",`+
+			`"end_of_sales":"2027-12-31T23:59:59Z",`+
+			`"end_of_security_support":"2028-06-30T23:59:59Z",`+
+			`"general_availability":"2020-01-15T00:00:00Z",`+
+			`"last_updated":"2025-07-01T12:00:00Z"}`,
+		string(data),
+	)
+}
+
+func TestSortKeys(t *testing.T) {
+	sorted, err := SortKeys([]byte(`{"b": {"d": 1, "c": [{"f": 2, "e": "x&y"}]}, "a": true}`))
+	require.NoError(t, err)
+	//nolint:testifylint // byte-exact comparison: the test asserts key order
+	require.Equal(t, `{"a":true,"b":{"c":[{"e":"x&y","f":2}],"d":1}}`, string(sorted))
+
+	_, err = SortKeys([]byte(`{"unterminated": `))
+	require.Error(t, err)
+}
+
+func TestCoreFileRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "core.eox.json")
+	require.NoError(t, WriteCoreFile(path, testCoreDocument()))
+
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	core, err := parser.ParseCoreFile(path)
+	require.NoError(t, err)
+	require.Equal(t, CoreSchema, core.GetSchema())
+	require.Equal(t, time.Date(2028, 12, 31, 23, 59, 59, 0, time.UTC), core.GetEndOfLife().AsTime())
+
+	_, err = parser.ParseCoreFile(filepath.Join(t.TempDir(), "missing.json"))
+	require.Error(t, err)
+}
+
+func TestCoreStreamRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteCore(&buf, testCoreDocument()))
+
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	core, err := parser.ParseCoreReader(&buf)
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC), core.GetEndOfSecuritySupport().AsTime())
+}
+
+func TestParseCoreURL(t *testing.T) {
+	data, err := MarshalCore(testCoreDocument())
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/core.json" {
+			w.Write(data) //nolint:errcheck,gosec
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	core, err := parser.ParseCoreURL(t.Context(), srv.URL+"/core.json")
+	require.NoError(t, err)
+	require.Equal(t, CoreSchema, core.GetSchema())
+
+	_, err = parser.ParseCoreURL(t.Context(), srv.URL+"/nope.json")
+	require.Error(t, err)
+}
+
+func TestMarshalCoreString(t *testing.T) {
+	s, err := MarshalCoreString(testCoreDocument())
+	require.NoError(t, err)
+	require.Contains(t, s, `"end_of_life":"2028-12-31T23:59:59Z"`)
+}
+
+func TestShellIOHelpers(t *testing.T) {
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	shell, err := parser.ParseShellFile("testdata/latest.eox.json")
+	require.NoError(t, err)
+	require.Len(t, shell.GetStatements(), 2)
+
+	s, err := MarshalShellString(shell)
+	require.NoError(t, err)
+	require.NotEmpty(t, s)
+
+	path := filepath.Join(t.TempDir(), "shell.eox.json")
+	require.NoError(t, WriteShellFile(path, shell))
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteShell(&buf, shell))
+
+	reparsed, err := parser.ParseShellReader(&buf)
+	require.NoError(t, err)
+	require.Len(t, reparsed.GetStatements(), 2)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(s)) //nolint:errcheck,gosec
+	}))
+	defer srv.Close()
+
+	fetched, err := parser.ParseShellURL(t.Context(), srv.URL)
+	require.NoError(t, err)
+	require.Len(t, fetched.GetStatements(), 2)
+}

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@
 package openeox
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -21,7 +22,11 @@ func NewParser() (*Parser, error) {
 // Parser implements the OpenEOX parser. It handles the "tba" (to be
 // announced) values in eox_timestamp_t fields by mapping them to a
 // sentinel timestamp. Use [IsTBA] to check parsed timestamps.
-type Parser struct{}
+type Parser struct {
+	// SkipValidation disables JSON schema validation of core documents
+	// when parsing.
+	SkipValidation bool
+}
 
 //nolint:unused
 type schemaFinder struct {
@@ -68,8 +73,18 @@ func (p *Parser) ParseShell(data []byte) (*Shell, error) {
 
 // ParseCore parses a JSON-encoded OpenEoX core document. Any "tba"
 // values in lifecycle timestamp fields are converted to the sentinel
-// timestamp (see [IsTBA]).
+// timestamp (see [IsTBA]). Unless [Parser.SkipValidation] is set, the
+// document is validated against the upstream OpenEoX core JSON schema;
+// validation errors wrap [ErrInvalidDocument]. Documents declaring a
+// superseded schema URI (such as [CoreSchemaLegacy]) are validated as if
+// they declared [CoreSchema].
 func (p *Parser) ParseCore(data []byte) (*Core, error) {
+	if !p.SkipValidation {
+		if err := validateCore(data); err != nil {
+			return nil, err
+		}
+	}
+
 	processed, err := preprocessTBACore(data)
 	if err != nil {
 		return nil, err
@@ -86,23 +101,43 @@ func (p *Parser) ParseCore(data []byte) (*Core, error) {
 }
 
 // MarshalShell serializes a Shell to JSON in the upstream OpenEoX format.
-// Sentinel TBA timestamps are written as "tba".
+// Sentinel TBA timestamps are written as "tba" and object keys are sorted.
 func MarshalShell(s *Shell) ([]byte, error) {
 	marshaler := protojson.MarshalOptions{}
 	data, err := marshaler.Marshal(s)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling json: %w", err)
 	}
-	return postprocessTBA(data), nil
+	return SortKeys(postprocessTBA(data))
 }
 
 // MarshalCore serializes a Core to JSON in the upstream OpenEoX format.
-// Sentinel TBA timestamps are written as "tba".
+// Sentinel TBA timestamps are written as "tba" and object keys are sorted.
 func MarshalCore(c *Core) ([]byte, error) {
 	marshaler := protojson.MarshalOptions{}
 	data, err := marshaler.Marshal(c)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling json: %w", err)
 	}
-	return postprocessTBA(data), nil
+	return SortKeys(postprocessTBA(data))
+}
+
+// SortKeys returns the JSON document with all object keys sorted
+// lexicographically at every nesting level. The marshal functions apply
+// it automatically to their output.
+func SortKeys(data []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("decoding document: %w", err)
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encoding document: %w", err)
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
 }

--- a/schema/core.json
+++ b/schema/core.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
+  "$id": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json",
+  "title": "EoX Information - Core",
+  "description": "The schema for representing End-of-Life (EoL), End-of-Security-Support (EoSSec) and other End-of information in OpenEoX.",
+  "type": "object",
+  "$defs": {
+    "eox_timestamp_t": {
+      "title": "EoX Timestamp",
+      "description": "Contains the timestamp at which the product reaches the specified stage or the indicator that this is still 'to be announced'.",
+      "type": "string",
+      "oneOf": [
+        {
+          "format": "date-time"
+        },
+        {
+          "const": "tba"
+        }
+      ]
+    }
+  },
+  "required": [
+    "$schema",
+    "end_of_life",
+    "end_of_security_support",
+    "last_updated"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "OpenEoX Core Schema",
+      "description": "Specifies the schema the JSON object must be valid against.",
+      "type": "string",
+      "const": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/core.json"
+    },
+    "end_of_life": {
+      "title": "End-of-Life",
+      "description": "Indicates the last day when the particular product is officially supported in any way by the vendor.",
+      "$ref": "#/$defs/eox_timestamp_t"
+    },
+    "end_of_sales": {
+      "title": "End-of-Sales",
+      "description": "Indicates the last day when a particular product may be ordered by customers from vendor sales channels.",
+      "$ref": "#/$defs/eox_timestamp_t"
+    },
+    "end_of_security_support": {
+      "title": "End-of-Security-Support",
+      "description": "Indicates the last day when the vendor has committed to providing security remediations for the particular product.",
+      "$ref": "#/$defs/eox_timestamp_t"
+    },
+    "general_availability": {
+      "title": "General Availability",
+      "description": "Indicates the first day when the particular product is officially launched and made accessible to the general public or through its intended distribution channels.",
+      "$ref": "#/$defs/eox_timestamp_t"
+    },
+    "last_updated": {
+      "title": "Timestamp of last change",
+      "description": "Contains the RFC 3339 timestamp when the record was last updated.",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "unevaluatedProperties": false
+}

--- a/schema/meta.json
+++ b/schema/meta.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/applicator": true,
+    "https://json-schema.org/draft/2020-12/vocab/unevaluated": true,
+    "https://json-schema.org/draft/2020-12/vocab/validation": true,
+    "https://json-schema.org/draft/2020-12/vocab/meta-data": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-assertion": true,
+    "https://json-schema.org/draft/2020-12/vocab/content": true
+  },
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/applicator" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/unevaluated" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/validation" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/meta-data" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/content" }
+  ]
+}

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package openeox
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// ErrInvalidDocument is wrapped in the errors returned when a parsed
+// document does not conform to the OpenEoX core JSON schema.
+var ErrInvalidDocument = errors.New("document does not conform to the OpenEoX core schema")
+
+// The OpenEoX core schema (CSD01 RC3) and the meta schema it declares,
+// copied verbatim from oasis-tcs/openeox at commit fd771fe.
+var (
+	//go:embed schema/core.json
+	coreSchemaData []byte
+
+	//go:embed schema/meta.json
+	metaSchemaData []byte
+)
+
+// metaSchemaURL is the $schema URI declared by the upstream core schema.
+const metaSchemaURL = "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json"
+
+// coreSchemaAliases lists superseded schema URIs still accepted in the
+// $schema field of core documents. Documents declaring them are validated
+// as if they declared CoreSchema.
+var coreSchemaAliases = map[string]struct{}{
+	CoreSchemaLegacy: {},
+	"https://docs.oasis-open.org/openeox/tbd/schema/core.json": {},
+}
+
+var (
+	coreValidator     *jsonschema.Schema
+	coreValidatorOnce sync.Once
+	errCoreValidator  error
+)
+
+// compileCoreValidator compiles the embedded core schema on first use.
+func compileCoreValidator() (*jsonschema.Schema, error) {
+	coreValidatorOnce.Do(func() {
+		compiler := jsonschema.NewCompiler()
+		compiler.Draft = jsonschema.Draft2020
+		compiler.AssertFormat = true
+		if err := compiler.AddResource(metaSchemaURL, bytes.NewReader(metaSchemaData)); err != nil {
+			errCoreValidator = fmt.Errorf("loading meta schema: %w", err)
+			return
+		}
+		if err := compiler.AddResource(CoreSchema, bytes.NewReader(coreSchemaData)); err != nil {
+			errCoreValidator = fmt.Errorf("loading core schema: %w", err)
+			return
+		}
+		coreValidator, errCoreValidator = compiler.Compile(CoreSchema)
+	})
+	return coreValidator, errCoreValidator
+}
+
+// validateCore checks a raw core document against the upstream OpenEoX
+// core JSON schema before it is unmarshaled into the Core type.
+func validateCore(data []byte) error {
+	schema, err := compileCoreValidator()
+	if err != nil {
+		return err
+	}
+
+	var doc any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("decoding core document: %w", err)
+	}
+
+	if obj, ok := doc.(map[string]any); ok {
+		if s, ok := obj["$schema"].(string); ok {
+			if _, isAlias := coreSchemaAliases[s]; isAlias {
+				obj["$schema"] = CoreSchema
+			}
+		}
+	}
+
+	if err := schema.Validate(doc); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDocument, err)
+	}
+	return nil
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package openeox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// coreDoc builds a core document declaring the given schema URI with the
+// supplied body fields.
+func coreDoc(schemaURI, fields string) []byte {
+	return []byte(`{"$schema": "` + schemaURI + `", ` + fields + `}`)
+}
+
+const validCoreFields = `"end_of_life": "2027-12-31T23:59:59Z",
+	"end_of_security_support": "2027-06-30T23:59:59Z",
+	"last_updated": "2025-04-30T10:00:00Z"`
+
+func TestParseCoreValidation(t *testing.T) {
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name    string
+		doc     []byte
+		mustErr bool
+	}{
+		{"valid", coreDoc(CoreSchema, validCoreFields), false},
+		{"legacy-schema-uri", coreDoc(CoreSchemaLegacy, validCoreFields), false},
+		{"draft-schema-uri", coreDoc("https://docs.oasis-open.org/openeox/tbd/schema/core.json", validCoreFields), false},
+		{"tba-values", coreDoc(CoreSchema, `"end_of_life": "tba",
+			"end_of_security_support": "tba",
+			"last_updated": "2025-04-30T10:00:00Z"`), false},
+		{"all-fields", coreDoc(CoreSchema, validCoreFields+`,
+			"end_of_sales": "2026-12-31T23:59:59Z",
+			"general_availability": "2020-03-15T00:00:00Z"`), false},
+		{"missing-last-updated", coreDoc(CoreSchema, `"end_of_life": "tba",
+			"end_of_security_support": "tba"`), true},
+		{"missing-schema", []byte(`{` + validCoreFields + `}`), true},
+		{"unknown-schema-uri", coreDoc("https://example.com/other.json", validCoreFields), true},
+		{"tba-last-updated", coreDoc(CoreSchema, `"end_of_life": "tba",
+			"end_of_security_support": "tba",
+			"last_updated": "tba"`), true},
+		{"bad-timestamp", coreDoc(CoreSchema, `"end_of_life": "someday",
+			"end_of_security_support": "2027-06-30T23:59:59Z",
+			"last_updated": "2025-04-30T10:00:00Z"`), true},
+		{"extra-property", coreDoc(CoreSchema, validCoreFields+`, "extra": true`), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			core, err := parser.ParseCore(tc.doc)
+			if tc.mustErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidDocument)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, core)
+		})
+	}
+}
+
+func TestParseCoreSkipValidation(t *testing.T) {
+	parser := &Parser{SkipValidation: true}
+
+	// Missing last_updated fails validation but parses when it is disabled.
+	doc := coreDoc(CoreSchema, `"end_of_life": "tba", "end_of_security_support": "tba"`)
+
+	_, err := (&Parser{}).ParseCore(doc)
+	require.ErrorIs(t, err, ErrInvalidDocument)
+
+	core, err := parser.ParseCore(doc)
+	require.NoError(t, err)
+	require.True(t, IsTBA(core.GetEndOfLife()))
+}
+
+func TestParseCorePreservesLegacySchema(t *testing.T) {
+	parser, err := NewParser()
+	require.NoError(t, err)
+
+	// Validation treats legacy URIs as aliases but the parsed document
+	// keeps the schema it declared.
+	core, err := parser.ParseCore(coreDoc(CoreSchemaLegacy, validCoreFields))
+	require.NoError(t, err)
+	require.Equal(t, CoreSchemaLegacy, core.GetSchema())
+}


### PR DESCRIPTION
This PR adds to the library the required methods to conform with the [OpenEoX spec clause 9](https://docs.oasis-open.org/openeox/eox-core/v1.0/eox-core-v1.0.html#conformance) as a "Library with basic validation". We now mebed the schemas to allow the validator to work without fetching it.